### PR TITLE
Simple import sort fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ module.exports = {
       },
     ],
     'prefer-spread': 'error',
-    'simple-import-sort/sort': [
+    'simple-import-sort/imports': [
       1,
       {
         groups: [['^\\u0000'], ['^[^.]'], ['^\\.']],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-maasglobal",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "ESLint config for MaaS projects",
   "author": "MaaS Team",
   "keywords": [


### PR DESCRIPTION
simple-import-sort/sort is obsolete, superseded by: simple-import-sort/imports

https://github.com/lydell/eslint-plugin-simple-import-sort/blob/main/CHANGELOG.md#version-600-2020-11-15